### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,7 +23,7 @@ jobs:
         yarn
         yarn build
         yarn test
-    - uses: elgohr/Publish-Docker-Github-Action@2.7
+    - uses: elgohr/Publish-Docker-Github-Action@v5
       name: Publish docker image
       with:
         name: zeekozhu/text-maid


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore